### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -29,7 +29,7 @@ jobs:
           # Get a random AAD and ADFS environment
           $inputIdProvider = "${{ github.event.inputs.identity_provider }}" 
           $environmentJsonArray = Resolve-IdProviderToEnvironmentJSONArray -Config $config -InputIdentityProvider $inputIdProvider
-          echo "::set-output name=ENVIRONMENT_JSON_ARRAY::${environmentJsonArray}"
+          echo "ENVIRONMENT_JSON_ARRAY=${environmentJsonArray}" >> "$GITHUB_OUTPUT"
 
           # Create JSON string output of samples to run.
           $branch = ""
@@ -52,7 +52,7 @@ jobs:
           }
           $inputJsonArrayString = Resolve-SamplesInputToSamplesJsonArray -Config $config `
             -Samples $inputSamples
-          echo "::set-output name=INPUT_JSON_ARRAY::${inputJsonArrayString}"
+          echo "INPUT_JSON_ARRAY=${inputJsonArrayString}" >> "$GITHUB_OUTPUT"
 
     outputs:
       ENVIRONMENT_JSON_ARRAY: ${{ steps.prepare_ci_and_input.outputs.ENVIRONMENT_JSON_ARRAY }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter